### PR TITLE
Add option WithCustomTLS to allow passing in a raw tls.Config

### DIFF
--- a/client.go
+++ b/client.go
@@ -159,6 +159,14 @@ func WithTLS(certFile, keyFile string, caCert string, serverNameOverride string,
 	}
 }
 
+// WithCustomTLS replaces the TLS options with a custom tls.Config 
+func WithCustomTLS(config *tls.Config) Option {
+	return func(c *client) error {
+		c.options.tlsConfig = config
+		return nil
+	}
+}
+
 // WithDialTimeout for connection time out (time in second)
 func WithDialTimeout(timeout uint16) Option {
 	return func(c *client) error {


### PR DESCRIPTION
Allows for more flexibility than the normal WithTLS() option (for example if certificates are not on disk, or key file is encrypted)