### PR TITLE
Remove version downgrade in reconnections

### DIFF
--- a/client_conn_options.go
+++ b/client_conn_options.go
@@ -196,7 +196,7 @@ reconnect:
 			reconnectDelay = c.maxDelay
 		}
 
-		parent.addWorker(func() { c.connect(parent, server, version-1, reconnectDelay) })
+		parent.addWorker(func() { c.connect(parent, server, version, reconnectDelay) })
 	case <-parent.stopSig:
 		return
 	}


### PR DESCRIPTION
In this pull request, I'm going to skip the downgrade of MQTT version in case of unsupported new version. The reason is that the previous behaviour doesn't prevent unsupported version to occur causing during reconnection `NET encode error trying encode/decode packet with unsupported MQTT version` (which closes some, not all, of the added workers).

In this way the version is downgraded as long as it is supported (V5, V311)