### PR TITLE
don't check protocol version for keepalive packets

### DIFF
--- a/client_conn.go
+++ b/client_conn.go
@@ -351,7 +351,7 @@ func (c *clientConn) handleNetRecv() {
 			return
 		}
 
-		if pkt.Version() != c.protoVersion {
+		if pkt.Type() != CtrlPingResp && pkt.Version() != c.protoVersion {
 			// protocol version not match, exit
 			c.exit()
 			return


### PR DESCRIPTION
It seems that when using the V5 protocol version the client keeps disconnecting and then reconnecting. I tracked this problem down to the keepalive packets not having adequate protocol version information.